### PR TITLE
added item: battery indicator

### DIFF
--- a/weather-cal.js
+++ b/weather-cal.js
@@ -873,46 +873,8 @@ function text(input = null) {
   return displayText
 }
 
-// Provide the SF Symbols battery icon depending on the battery level
-function provideBatteryIcon() {
-
-  const batteryLevel = Device.batteryLevel()
-
-  if ( Device.isCharging() ) {
-
-    let batIcon = SFSymbol.named("battery.100.bolt")
-    batIcon.applyLightWeight()
-
-    return batIcon.image
-
-  } else
-
-    if ( Math.round(batteryLevel * 100) > 65 ) {
-
-      let batIcon = SFSymbol.named("battery.100")
-      batIcon.applyLightWeight()
-
-      return batIcon.image
-
-    } else if ( Math.round(batteryLevel * 100) > 30 ) {
-
-      let batIcon = SFSymbol.named("battery.25")
-      batIcon.applyLightWeight()
-
-      return batIcon.image
-
-    } else {
-
-      let batIcon = SFSymbol.named("battery.0")
-      batIcon.applySemiboldWeight()
-
-      return batIcon.image
-    }
-
-}
-
 // Add a battery element to the widget; consisting of a battery icon and percentage
-async function battery(column, alignment) {
+async function battery(column) {
 
   // Get battery level via Scriptable function and format it in a convenient way
   function getBatteryLevel() {
@@ -926,7 +888,7 @@ async function battery(column, alignment) {
   const batteryLevel = Device.batteryLevel()
   
   // Set up the battery level item
-  let batteryStack = align(column, alignment)
+  let batteryStack = align(column)
   batteryStack.layoutHorizontally()
   batteryStack.centerAlignContent()
 
@@ -986,6 +948,44 @@ function provideTextSymbol(shape) {
   }
   // Default to the rectangle.
   return "\u2759" 
+}
+
+// Provide the SF Symbols battery icon depending on the battery level
+function provideBatteryIcon() {
+
+  const batteryLevel = Device.batteryLevel()
+
+  if ( Device.isCharging() ) {
+
+    let batIcon = SFSymbol.named("battery.100.bolt")
+    batIcon.applyLightWeight()
+
+    return batIcon.image
+
+  } else
+
+    if ( Math.round(batteryLevel * 100) > 65 ) {
+
+      let batIcon = SFSymbol.named("battery.100")
+      batIcon.applyLightWeight()
+
+      return batIcon.image
+
+    } else if ( Math.round(batteryLevel * 100) > 30 ) {
+
+      let batIcon = SFSymbol.named("battery.25")
+      batIcon.applyLightWeight()
+
+      return batIcon.image
+
+    } else {
+
+      let batIcon = SFSymbol.named("battery.0")
+      batIcon.applySemiboldWeight()
+
+      return batIcon.image
+    }
+
 }
 
 // Provide a symbol based on the condition.

--- a/weather-cal.js
+++ b/weather-cal.js
@@ -34,7 +34,7 @@ const padding = 10
 // Set the width of the column, or set to 0 for an automatic width.
 
 // You can add items to the column: 
-// date, greeting, events, current, future, text("Your text here")
+// date, greeting, events, current, future, battery, text("Your text here")
 // You can also add a left, center, or right to the list. Everything after it will be aligned that way.
 
 // Make sure to always put a comma after each item.
@@ -173,6 +173,8 @@ const textFormat = {
   tinyTemp:    { size: 12, color: "", font: "" },
   
   customText:  { size: 14, color: "", font: "" },
+  
+  battery:    { size: 18, color: "", font: "medium" }
 }
 
 /*
@@ -869,6 +871,87 @@ function text(input = null) {
     const textDisplay = provideText(input, textStack, textFormat.customText)
   }
   return displayText
+}
+
+/ Provide the SF Symbols battery icon depending on the battery level
+function provideBatteryIcon() {
+
+  const batteryLevel = Device.batteryLevel()
+
+  if ( Device.isCharging() ) {
+
+    let batIcon = SFSymbol.named("battery.100.bolt")
+    batIcon.applyLightWeight()
+
+    return batIcon.image
+
+  } else
+
+    if ( Math.round(batteryLevel * 100) > 65 ) {
+
+      let batIcon = SFSymbol.named("battery.100")
+      batIcon.applyLightWeight()
+
+      return batIcon.image
+
+    } else if ( Math.round(batteryLevel * 100) > 30 ) {
+
+      let batIcon = SFSymbol.named("battery.25")
+      batIcon.applyLightWeight()
+
+      return batIcon.image
+
+    } else {
+
+      let batIcon = SFSymbol.named("battery.0")
+      batIcon.applySemiboldWeight()
+
+      return batIcon.image
+    }
+
+}
+
+// Add a battery element to the widget; consisting of a battery icon and percentage
+async function battery(column, alignment) {
+
+  // Get battery level via Scriptable function and format it in a convenient way
+  function getBatteryLevel() {
+  
+    const batteryLevel = Device.batteryLevel()
+    const batteryPercentage = `${Math.round(batteryLevel * 100)}%`
+
+    return batteryPercentage
+  }
+
+  const batteryLevel = Device.batteryLevel()
+  
+  // Set up the battery level item
+  let batteryStack = align(column, alignment)
+  batteryStack.layoutHorizontally()
+  batteryStack.centerAlignContent()
+
+  let batteryIcon = batteryStack.addImage(provideBatteryIcon())
+  batteryIcon.imageSize = new Size(30,30)
+  
+
+  // Change the battery icon to red if battery level is <= 20 to match system behavior
+  if ( Math.round(batteryLevel * 100) > 20 || Device.isCharging() ) {
+
+    batteryIcon.tintColor = Color.white()
+
+  } else {
+
+    batteryIcon.tintColor = Color.red()
+
+  }
+
+  batteryStack.addSpacer(8)
+
+  // Display the battery status
+  let batteryInfo = provideText(getBatteryLevel(), batteryStack, textFormat.battery)
+
+  batteryStack.setPadding(10, 10, 10, 10)
+
 }
 
 /*

--- a/weather-cal.js
+++ b/weather-cal.js
@@ -873,7 +873,7 @@ function text(input = null) {
   return displayText
 }
 
-/ Provide the SF Symbols battery icon depending on the battery level
+// Provide the SF Symbols battery icon depending on the battery level
 function provideBatteryIcon() {
 
   const batteryLevel = Device.batteryLevel()


### PR DESCRIPTION
Like I mentioned in the Automators forum a few days ago, I added a battery indicator to the widget.

Since newer iPhones won't show the battery percentage on the home screen anymore (unless you pull down the control center) there's probably a good reason to include such an item to this "everything at a glance" widget.