### PR TITLE
Add COVID tokens for yesterday’s cases and deaths

### DIFF
--- a/weather-cal-code.js
+++ b/weather-cal-code.js
@@ -1362,7 +1362,7 @@ const weatherCal = {
       const covidReqToday = "https://coronavirus-19-api.herokuapp.com/countries/" + this.settings.covid.country
       let covidDataRawToday = await new Request(covidReqToday).loadJSON()
       // Combine today's data with a few fields from yesterday's data
-      const covidDataRaw = {
+      covidDataRaw = {
         ...covidDataRawToday,
         ...{
           yesterdayCases: covidDataRawYesterday['positiveIncrease'],

--- a/weather-cal-code.js
+++ b/weather-cal-code.js
@@ -2030,7 +2030,7 @@ const weatherCal = {
 
     // Set up the battery icon.
     const batteryIcon = batteryStack.addImage(this.provideBatteryIcon(Device.batteryLevel(),Device.isCharging()))
-    batteryIcon.imageSize = new Size(30,30)
+    batteryIcon.imageSize = new Size(30,18)
 
     // Change the battery icon to red if battery level is less than 20%.
     const batteryLevel = Math.round(Device.batteryLevel() * 100)
@@ -2096,7 +2096,7 @@ const weatherCal = {
 
     // Add the correct symbol.
     const symbol = sunriseStack.addImage(SFSymbol.named(symbolName).image)
-    symbol.imageSize = new Size(22,22)
+    symbol.imageSize = new Size(18,18)
     this.tintIcon(symbol, this.format.sunrise)
 
     sunriseStack.addSpacer(this.padding)


### PR DESCRIPTION
I retrieve daily historical COVID numbers from a different API and combine a few of those numbers with the COVID data from the original API. Note that I rename the keys from the alternate API to match the conventions in the original API.

I also added the two new COVID tokens (`{yesterdayCases}` and `{yesterdayDeaths}`) to the pop-up description when editing the COVID text.

TODO: Make the country for the alternate API a variable. It’s currently set to “us”, and unfortunately the country names in the alternate API don’t necessarily match those in the original API, so a separate country option would be required, or we’d need to map countries between the two.