### PR TITLE
Fixed Issue #100

### DIFF
--- a/weather-cal-code.js
+++ b/weather-cal-code.js
@@ -1028,7 +1028,7 @@ const weatherCal = {
     const reminderSettings = this.settings.reminders
 
     if (this.data.reminders.length == 0) {
-      if (reminderSettings.noRemindersBehavior == "message" && this.localization.noRemindersMessage.length) { return this.provideText(this.localization.noRemindersMessage, messageStack, this.format.noReminders, true) }
+      if (reminderSettings.noRemindersBehavior == "message" && this.localization.noRemindersMessage.length) { return this.provideText(this.localization.noRemindersMessage, column, this.format.noReminders, true) }
       if (this[reminderSettings.noRemindersBehavior]) { return await this[reminderSettings.noRemindersBehavior](column) }
     }
 

--- a/weather-cal-code.js
+++ b/weather-cal-code.js
@@ -478,7 +478,7 @@ const weatherCal = {
       const imagePath = this.fm.joinPath(this.fm.joinPath(this.fm.documentsDirectory(), "Weather Cal"), name + ".jpg")
 
       if (this.fm.fileExists(imagePath)) {
-        await this.fm.downloadFileFromiCloud(imagePath)
+        if (this.fm.isFileStoredIniCloud(imagePath)) { await this.fm.downloadFileFromiCloud(imagePath) }
         this.widget.backgroundImage = this.fm.readImage(imagePath)
 
       } else if (config.runsInWidget) {
@@ -1028,7 +1028,7 @@ const weatherCal = {
     const reminderSettings = this.settings.reminders
 
     if (this.data.reminders.length == 0) {
-      if (reminderSettings.noRemindersBehavior == "message" && this.localization.noRemindersMessage.length) { return this.provideText(this.localization.noRemindersMessage, column, this.format.noReminders, true) }
+      if (reminderSettings.noRemindersBehavior == "message" && this.localization.noRemindersMessage.length) { return this.provideText(this.localization.noRemindersMessage, messageStack, this.format.noReminders, true) }
       if (this[reminderSettings.noRemindersBehavior]) { return await this[reminderSettings.noRemindersBehavior](column) }
     }
 

--- a/weather-cal-code.js
+++ b/weather-cal-code.js
@@ -171,6 +171,20 @@ const weatherCal = {
         if ((await alert.present()) == 0) {
           if (this.fm.fileExists(this.bgPath)) { this.fm.remove(this.bgPath) }
           if (this.fm.fileExists(this.prefPath)) { this.fm.remove(this.prefPath) }
+          let locationPath = this.fm.joinPath(this.fm.libraryDirectory(), "weather-cal-location")
+          if (this.fm.fileExists(locationPath)) { this.fm.remove(locationPath) }
+          let sunrisePath = this.fm.joinPath(this.fm.libraryDirectory(), "weather-cal-sunrise")
+          if (this.fm.fileExists(sunrisePath)) { this.fm.remove(sunrisePath) }
+          let cachePath = this.fm.joinPath(this.fm.libraryDirectory(), "weather-cal-cache")
+          if (this.fm.fileExists(cachePath)) { this.fm.remove(cachePath) }
+          let covidPath = this.fm.joinPath(this.fm.libraryDirectory(), "weather-cal-covid")
+          if (this.fm.fileExists(covidPath)) { this.fm.remove(covidPath) }
+          let newsPath = this.fm.joinPath(this.fm.libraryDirectory(), "weather-cal-news")
+          if (this.fm.fileExists(newsPath)) { this.fm.remove(newsPath) }
+          let imagePath = this.fm.joinPath(this.fm.joinPath(this.fm.documentsDirectory(), "Weather Cal"), this.name + ".jpg")
+          if (this.fm.fileExists(imagePath)) { this.fm.remove(imagePath) }
+          let dupePath = this.fm.joinPath(this.fm.joinPath(this.fm.documentsDirectory(), "Weather Cal"), this.name + " 2.jpg")
+          if (this.fm.fileExists(dupePath)) { this.fm.remove(dupePath) }
           const success = await this.downloadCode(this.name, this.widgetUrl)
           const message = success ? "This script has been reset. Close the script and reopen it for the change to take effect." : "The reset failed."
           await this.generateAlert(message)
@@ -728,7 +742,7 @@ const weatherCal = {
   // Set up the location data object.
   async setupLocation() {
     const locationPath = this.fm.joinPath(this.fm.libraryDirectory(), "weather-cal-location")
-    const locationCache = this.getCache(locationPath, this.settings ? parseInt(this.settings.updateLocation) : null)
+    const locationCache = this.getCache(locationPath, this.settings ? parseInt(this.settings.widget.updateLocation) : null)
     let location
     
     if (!locationCache || locationCache.cacheExpired) {


### PR DESCRIPTION
This commit fixes Issue #100 location not updating.
- There was a small error in using the setting parameter "updateLocation". It was not read correctly when checking if the cache is outdated, so it was always used the location from the cache.
- I added deletion of the cache files and the background images when perform "Completely reset widget". This (cache) might effect all Weather Cal widgets on this device. I did not delete the setup file, because this might effect other Weather Cal widgets too and would result in re-askig the api-key on the next run.