### PR TITLE
Fix the codeFilename typo

### DIFF
--- a/weather-cal.js
+++ b/weather-cal.js
@@ -42,7 +42,7 @@ const layout = `
  */
 
 // Names of Weather Cal elements.
-const codeFilename = "Weather Cal code"
+const codeFilename = "weather-cal-code"
 const gitHubUrl = "https://raw.githubusercontent.com/mzeryck/Weather-Cal/main/weather-cal-code.js"
 
 // Determine if the user is using iCloud.


### PR DESCRIPTION
Make sure in the `weather-cal` script, you set the codeFilename variable to be `weather-cal-code`, seems the script on GitHub has the old name in it so it was downloading a fresh copy of the code and saving it with `Weather Cal code` as the name, then using that script for the code of the widget instead of the one we modified.